### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/rviz_plugin_tutorial/CMakeLists.txt
+++ b/rviz_plugin_tutorial/CMakeLists.txt
@@ -27,7 +27,7 @@ qt5_wrap_cpp(MOC_FILES
   include/rviz_plugin_tutorial/point_display.hpp
 )
 
-add_library(point_display src/point_display.cpp ${MOC_FILES})
+add_library(point_display SHARED src/point_display.cpp ${MOC_FILES})
 target_include_directories(point_display PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
Newer Cmake versions 3.25.2 for example, might produce a .a file not .so.
In that case the plugin manager cant find the binary anymore